### PR TITLE
Fix/error report navigation for possible categories

### DIFF
--- a/src/app/find/errorReports/ErrorReportContainer.jsx
+++ b/src/app/find/errorReports/ErrorReportContainer.jsx
@@ -180,8 +180,8 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   getLocation: () => dispatch(getLocation(ownProps.match.params.locationId)),
-  goToThanksScreen: () => ownProps.history.push(`/find/location/${ownProps.match.params.locationId}/errorreports/thanks`),
-  goToErrorReportTextScreen: () => ownProps.history.push(`/find/location/${ownProps.match.params.locationId}/errorreports/text`),
+  goToThanksScreen: () => ownProps.history.push(`${ownProps.match.url}/thanks`),
+  goToErrorReportTextScreen: () => ownProps.history.push(`${ownProps.match.url}/text`),
   goToViewLocation: () => ownProps.history.push(`/find/location/${ownProps.match.params.locationId}`),
   postErrorReport: data => dispatch(postErrorReport(
     ownProps.match.params.locationId,

--- a/src/app/find/errorReports/ErrorReportText.jsx
+++ b/src/app/find/errorReports/ErrorReportText.jsx
@@ -67,9 +67,6 @@ ErrorReportText.propTypes = {
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   goToViewLocation: PropTypes.func.isRequired,
-  match: PropTypes.shape({
-    url: PropTypes.string,
-  }).isRequired,
 };
 
 export default ErrorReportText;


### PR DESCRIPTION
Minor changes to how the error report components navigate, that takes into consideration a possible `category` in the path URL.

Also removed unnecessary PropType checks for props that were previously removed.