### PR TITLE
fix/split-phone-numbers

### DIFF
--- a/src/app/find/locationDetails/LocationDetails.jsx
+++ b/src/app/find/locationDetails/LocationDetails.jsx
@@ -123,9 +123,6 @@ const renderLocation = (location, searchCategory) => {
       service.metadata.sources.some(source => source.includes('FPC')));
 
   const phones = [];
-  if (location.Organization.Phones) {
-    phones.push(...location.Organization.Phones);
-  }
   if (location.Phones) {
     location.Phones.forEach((phone) => {
       if (!phones.find(existingPhone => existingPhone.number === phone.number)) {


### PR DESCRIPTION
@Rovack 

I think these were the correct lines to remove, though you might want to double check. If you have a location that would be better suited for testing this functionality, please let me know it's ID/name.

Resulting phone number list with lines removed:
![Screen Shot 2020-06-05 at 3 25 14 PM](https://user-images.githubusercontent.com/56702911/83927295-5771a580-a741-11ea-8ea0-33f830d2414e.png)

Phone data related to this screenshot:
![Screen Shot 2020-06-05 at 3 25 40 PM](https://user-images.githubusercontent.com/56702911/83927347-7a03be80-a741-11ea-8ddb-304ee152f4f7.png)

