### PR TITLE
feat: add basic mixpanel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "history": "^4.7.2",
     "lodash.debounce": "^4.0.8",
     "lodash.ismatch": "^4.4.0",
+    "mixpanel-browser": "^2.38.0",
     "moment": "^2.22.0",
     "prop-types": "^15.6.1",
     "qs": "^6.7.0",

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -18,13 +18,15 @@ import NotFound from './notFound/NotFound';
 import LoadingLabel from '../components/form/LoadingLabel';
 
 import withTracker from '../components/routing/withTracker';
+import analytics from '../services/analytics';
 
 const TeamRouter = React.lazy(() => import('./team/Router'));
 const CommentsRouter = React.lazy(() => import('./comments/Router'));
 const findRouterPromise = import('./find/Router');
 const FindRouter = React.lazy(() => findRouterPromise);
 
-history.listen((location, action) => {
+history.listen(() => {
+  analytics.track('Page View');
   window.scrollTo(0, 0);
 });
 

--- a/src/app/find/mapPage/MapPage.jsx
+++ b/src/app/find/mapPage/MapPage.jsx
@@ -10,8 +10,8 @@ import LocationMarker from '../../../components/map/LocationMarker';
 import FiltersModal from './filters/FiltersModal';
 import Search from './Search';
 import ResultsBar from './ResultsBar';
+import analytics from '../../../services/analytics';
 import './mapPage.css';
-import Mixpanel from '../../../services/mixpanel';
 
 const minSearchResults = 3;
 
@@ -37,7 +37,6 @@ export default class MapPage extends Component {
   };
 
   componentDidMount() {
-    Mixpanel.track('Map Page Loaded');
     this.props.fetchCategories();
   }
 
@@ -215,7 +214,7 @@ export default class MapPage extends Component {
   };
 
   openFilterModal = () => {
-    Mixpanel.track('Filter Results Clicked', { categoryName: this.props.category.name });
+    analytics.track('Filter Results Clicked', { categoryName: this.props.category.name });
     this.setState({ isFilterModalOpen: true });
   }
 

--- a/src/app/find/mapPage/MapPage.jsx
+++ b/src/app/find/mapPage/MapPage.jsx
@@ -11,6 +11,7 @@ import FiltersModal from './filters/FiltersModal';
 import Search from './Search';
 import ResultsBar from './ResultsBar';
 import './mapPage.css';
+import Mixpanel from '../../../services/mixpanel';
 
 const minSearchResults = 3;
 
@@ -36,6 +37,7 @@ export default class MapPage extends Component {
   };
 
   componentDidMount() {
+    Mixpanel.track('Map Page Loaded');
     this.props.fetchCategories();
   }
 
@@ -213,6 +215,7 @@ export default class MapPage extends Component {
   };
 
   openFilterModal = () => {
+    Mixpanel.track('Filter Results Clicked', { categoryName: this.props.category.name });
     this.setState({ isFilterModalOpen: true });
   }
 

--- a/src/app/find/mapPage/MapPageContainer.jsx
+++ b/src/app/find/mapPage/MapPageContainer.jsx
@@ -5,7 +5,7 @@ import qs from 'qs';
 import { getTaxonomy } from '../../../services/api';
 import MapPage from './MapPage';
 import { selectableCategoryNames } from '../categories';
-import Mixpanel from '../../../services/mixpanel';
+import analytics from '../../../services/analytics';
 
 class MapPageContainer extends Component {
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -33,7 +33,7 @@ class MapPageContainer extends Component {
     this.props.history.push(`/find/${category.name}${this.props.location.search}`);
 
   goToCategory = (category) => {
-    Mixpanel.track('Category Selected', { categoryName: category.name });
+    analytics.track('Category Selected', { categoryName: category.name });
     this.props.history.push(`/find/${category.name}/questions`);
   }
 
@@ -43,7 +43,7 @@ class MapPageContainer extends Component {
       `/find/${categoryName}/location/${locationId}` :
       `/find/location/${locationId}`;
 
-    Mixpanel.track('Location Clicked', { locationId, url, categoryName });
+    analytics.track('Location Clicked', { locationId, url, categoryName });
 
     this.props.history.push(url);
   }

--- a/src/app/find/mapPage/MapPageContainer.jsx
+++ b/src/app/find/mapPage/MapPageContainer.jsx
@@ -5,6 +5,7 @@ import qs from 'qs';
 import { getTaxonomy } from '../../../services/api';
 import MapPage from './MapPage';
 import { selectableCategoryNames } from '../categories';
+import Mixpanel from '../../../services/mixpanel';
 
 class MapPageContainer extends Component {
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -31,14 +32,19 @@ class MapPageContainer extends Component {
   goToCategoryResults = category =>
     this.props.history.push(`/find/${category.name}${this.props.location.search}`);
 
-  goToCategory = category =>
+  goToCategory = (category) => {
+    Mixpanel.track('Category Selected', { categoryName: category.name });
     this.props.history.push(`/find/${category.name}/questions`);
+  }
 
   goToLocationDetails = (locationId) => {
     const { categoryName } = this.props.match.params;
     const url = categoryName ?
       `/find/${categoryName}/location/${locationId}` :
       `/find/location/${locationId}`;
+
+    Mixpanel.track('Location Clicked', { locationId, url, categoryName });
+
     this.props.history.push(url);
   }
 

--- a/src/app/find/mapPage/Search.jsx
+++ b/src/app/find/mapPage/Search.jsx
@@ -4,6 +4,7 @@ import Icon from '../../../components/icon';
 import Button from '../../../components/button';
 import { getCategoryIcon } from '../../../services/iconography';
 import './search.css';
+import Mixpanel from '../../../services/mixpanel';
 
 const minCharsForSuggestions = 3;
 
@@ -45,6 +46,7 @@ class Search extends Component {
 
   submitSearchString = () => {
     const searchString = this.state.modifiedSearchString;
+    Mixpanel.track('Search Initiated', { searchString });
     this.setState({
       isEnteringSearchString: false,
       modifiedSearchString: '',

--- a/src/app/find/mapPage/Search.jsx
+++ b/src/app/find/mapPage/Search.jsx
@@ -4,7 +4,7 @@ import Icon from '../../../components/icon';
 import Button from '../../../components/button';
 import { getCategoryIcon } from '../../../services/iconography';
 import './search.css';
-import Mixpanel from '../../../services/mixpanel';
+import analytics from '../../../services/analytics';
 
 const minCharsForSuggestions = 3;
 
@@ -46,7 +46,7 @@ class Search extends Component {
 
   submitSearchString = () => {
     const searchString = this.state.modifiedSearchString;
-    Mixpanel.track('Search Initiated', { searchString });
+    analytics.track('Search Initiated', { searchString });
     this.setState({
       isEnteringSearchString: false,
       modifiedSearchString: '',

--- a/src/app/landing/LandingPage.jsx
+++ b/src/app/landing/LandingPage.jsx
@@ -5,11 +5,13 @@ import Testimonial from './Testimonial';
 import PartnerPicture from './PartnerPicture';
 import { DESKTOP_BREAKPOINT } from '../../Constants';
 import './LandingPage.css';
+import Mixpanel from '../../services/mixpanel';
 
 const feedbackEmail = 'gogetta@streetlives.nyc';
 
 class LandingPage extends Component {
   getStarted = () => {
+    Mixpanel.track('Get Started Clicked');
     this.props.history.push('/find');
   };
 

--- a/src/app/landing/LandingPage.jsx
+++ b/src/app/landing/LandingPage.jsx
@@ -5,13 +5,13 @@ import Testimonial from './Testimonial';
 import PartnerPicture from './PartnerPicture';
 import { DESKTOP_BREAKPOINT } from '../../Constants';
 import './LandingPage.css';
-import Mixpanel from '../../services/mixpanel';
+import analytics from '../../services/analytics';
 
 const feedbackEmail = 'gogetta@streetlives.nyc';
 
 class LandingPage extends Component {
   getStarted = () => {
-    Mixpanel.track('Get Started Clicked');
+    analytics.track('Get Started Clicked');
     this.props.history.push('/find');
   };
 

--- a/src/config.js
+++ b/src/config.js
@@ -12,4 +12,5 @@ export default {
   googleMaps: process.env.REACT_APP_GMAPS_URL || 'https://maps.googleapis.com/maps/api/js?key=AIzaSyCFMDqEgQ6VWWJbROzZhHu-f6sktAmTEGU&v=3.exp&libraries=geometry,drawing,places',
   adminGroupName: process.env.REACT_APP_ADMIN_GROUP_NAME || 'StreetlivesAdmins',
   disableAuth: parseBoolean(process.env.REACT_APP_DISABLE_AUTH),
+  mixpanelToken: process.env.REACT_APP_MIXPANEL_TOKEN || '8dd3b51f7a1de357a05e954495ae616f',
 };

--- a/src/services/analytics.js
+++ b/src/services/analytics.js
@@ -1,6 +1,7 @@
 import mixpanel from 'mixpanel-browser';
+import config from '../config';
 
-const token = process.env.REACT_APP_MIXPANEL_TOKEN;
+const token = config.mixpanelToken;
 mixpanel.init(token);
 
 const analytics = {

--- a/src/services/analytics.js
+++ b/src/services/analytics.js
@@ -1,9 +1,9 @@
 import mixpanel from 'mixpanel-browser';
 
-const mixpanelToken = process.env.REACT_APP_MIXPANEL_TOKEN;
-mixpanel.init(mixpanelToken);
+const token = process.env.REACT_APP_MIXPANEL_TOKEN;
+mixpanel.init(token);
 
-const Mixpanel = {
+const analytics = {
   identify: (id) => {
     mixpanel.identify(id);
   },
@@ -20,4 +20,4 @@ const Mixpanel = {
   },
 };
 
-export default Mixpanel;
+export default analytics;

--- a/src/services/mixpanel.js
+++ b/src/services/mixpanel.js
@@ -1,0 +1,23 @@
+import mixpanel from 'mixpanel-browser';
+
+const mixpanelToken = process.env.REACT_APP_MIXPANEL_TOKEN;
+mixpanel.init(mixpanelToken);
+
+const Mixpanel = {
+  identify: (id) => {
+    mixpanel.identify(id);
+  },
+  alias: (id) => {
+    mixpanel.alias(id);
+  },
+  track: (name, props) => {
+    mixpanel.track(name, props);
+  },
+  people: {
+    set: (props) => {
+      mixpanel.people.set(props);
+    },
+  },
+};
+
+export default Mixpanel;


### PR DESCRIPTION
This adds a basic reusable mixpanel function to track user events with all the basic features mixpanel needs.

Note: before merging, we need to set up our .env files in both dev and prod environments with the API key for mixpanel.