### PR TITLE
feature/social-media-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
+    "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",
     "aws-amplify": "^1.1.6",

--- a/src/app/IconLibrary.js
+++ b/src/app/IconLibrary.js
@@ -31,6 +31,11 @@ import {
   faSpinner,
   faTrash,
 } from '@fortawesome/free-solid-svg-icons';
+import {
+  faTwitterSquare,
+  faFacebookSquare,
+  faLinkedin,
+} from '@fortawesome/free-brands-svg-icons';
 
 library.add(
   faChevronDown,
@@ -63,4 +68,7 @@ library.add(
   faPlus,
   faSpinner,
   faTrash,
+  faTwitterSquare,
+  faFacebookSquare,
+  faLinkedin,
 );

--- a/src/app/landing/LandingPage.css
+++ b/src/app/landing/LandingPage.css
@@ -176,16 +176,14 @@
   justify-content: center;
 }
 
-.LandingPage .Feedback .SocialIconsList {
-  margin-top: -5%;
-  margin-left: -3px;
+.LandingPage .Feedback .SocialIcons {
+  margin: -22px 36px 46px;
   font-size: 1.1rem;
 }
 
-.LandingPage .Feedback .SocialIconsList li {
-  display: inline;
-  list-style-type:none;
-  padding-right: 10px;
+.LandingPage .Feedback .SocialIcons a {
+  color: #FFFFFF;
+  padding-right: 8px;
 }
 
 .LandingPage h1 {

--- a/src/app/landing/LandingPage.css
+++ b/src/app/landing/LandingPage.css
@@ -176,6 +176,18 @@
   justify-content: center;
 }
 
+.LandingPage .Feedback .SocialIconsList {
+  margin-top: -5%;
+  margin-left: -3px;
+  font-size: 1.1rem;
+}
+
+.LandingPage .Feedback .SocialIconsList li {
+  display: inline;
+  list-style-type:none;
+  padding-right: 10px;
+}
+
 .LandingPage h1 {
   font-weight: bold;
   margin-left: 25px;

--- a/src/app/landing/LandingPage.css
+++ b/src/app/landing/LandingPage.css
@@ -166,6 +166,14 @@
   text-align: left;
 }
 
+.LandingPage .Feedback .SectionInner h2 {
+  margin-bottom: 6px;
+}
+
+.LandingPage .Feedback .SectionInner p {
+  margin-bottom: 16px;
+}
+
 .LandingPage .Feedback .FeedbackEmail {
   background-color: #FFFFFF;
   margin-left: 36px;
@@ -177,7 +185,7 @@
 }
 
 .LandingPage .Feedback .SocialIcons {
-  margin: -22px 36px 46px;
+  margin: 0px 36px 46px;
   font-size: 1.1rem;
 }
 

--- a/src/app/landing/LandingPage.jsx
+++ b/src/app/landing/LandingPage.jsx
@@ -344,23 +344,17 @@ class LandingPage extends Component {
         <div className="Feedback">
           <div className="SectionInner">
             <h2>Follow us on:</h2>
-            <ul className="SocialIconsList">
-              <li>
-                <a href="https://twitter.com/streetlivesnyc" rel="noreferrer" target="_blank">
-                  <FontAwesomeIcon icon={['fab', 'twitter-square']} size="2x" color="white" />
-                </a>
-              </li>
-              <li>
-                <a href="https://www.facebook.com/streetlivesnyc/" rel="noreferrer" target="_blank">
-                  <FontAwesomeIcon icon={['fab', 'facebook-square']} size="2x" color="white" />
-                </a>
-              </li>
-              <li>
-                <a href="https://www.linkedin.com/company/streetlives/" rel="noreferrer" target="_blank">
-                  <FontAwesomeIcon icon={['fab', 'linkedin']} size="2x" color="white" />
-                </a>
-              </li>
-            </ul>
+            <div className="SocialIcons">
+              <a href="https://twitter.com/streetlivesnyc" rel="noreferrer" target="_blank">
+                <Icon name={['fab', 'twitter-square']} size="2x" />
+              </a>
+              <a href="https://www.facebook.com/streetlivesnyc/" rel="noreferrer" target="_blank">
+                <Icon name={['fab', 'facebook-square']} size="2x" />
+              </a>
+              <a href="https://www.linkedin.com/company/streetlives/" rel="noreferrer" target="_blank">
+                <Icon name={['fab', 'linkedin']} size="2x" />
+              </a>
+            </div>
             <h2>We’re all about feedback</h2>
             <p>Tell us what you think at:</p>
             <div className="FeedbackEmail">

--- a/src/app/landing/LandingPage.jsx
+++ b/src/app/landing/LandingPage.jsx
@@ -1,4 +1,3 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { Component } from 'react';
 import Icon from '../../components/icon';
 import GetStartedButton from './GetStartedButton';

--- a/src/app/landing/LandingPage.jsx
+++ b/src/app/landing/LandingPage.jsx
@@ -1,3 +1,4 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { Component } from 'react';
 import Icon from '../../components/icon';
 import GetStartedButton from './GetStartedButton';
@@ -340,8 +341,26 @@ class LandingPage extends Component {
           </div>
         </div>
 
-        <div className="Feedback Section">
+        <div className="Feedback">
           <div className="SectionInner">
+            <h2>Follow us on:</h2>
+            <ul className="SocialIconsList">
+              <li>
+                <a href="https://twitter.com/streetlivesnyc" rel="noreferrer" target="_blank">
+                  <FontAwesomeIcon icon={['fab', 'twitter-square']} size="2x" color="white" />
+                </a>
+              </li>
+              <li>
+                <a href="https://www.facebook.com/streetlivesnyc/" rel="noreferrer" target="_blank">
+                  <FontAwesomeIcon icon={['fab', 'facebook-square']} size="2x" color="white" />
+                </a>
+              </li>
+              <li>
+                <a href="https://www.linkedin.com/company/streetlives/" rel="noreferrer" target="_blank">
+                  <FontAwesomeIcon icon={['fab', 'linkedin']} size="2x" color="white" />
+                </a>
+              </li>
+            </ul>
             <h2>We’re all about feedback</h2>
             <p>Tell us what you think at:</p>
             <div className="FeedbackEmail">

--- a/src/components/icon/Icon.jsx
+++ b/src/components/icon/Icon.jsx
@@ -46,7 +46,10 @@ function Icon({
 }
 
 Icon.propTypes = {
-  name: PropTypes.string.isRequired,
+  name: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.string,
+  ]).isRequired,
   custom: PropTypes.bool,
   size: PropTypes.string,
   circle: PropTypes.bool,


### PR DESCRIPTION
Hi @Rovack ,

I've added our social media icons + links to the bottom of the landing page.
This relates to the Asana task: [Add social media links to landing page](https://app.asana.com/0/1168502694533225/1185125349291226/f).

For the life of me, I couldn't use the `<Icon>` component to get these icons to render (like we do with all the other icons in the site). I'm guessing it's got something to do with the `name` prop (I tried all different names). I ended up importing the `FontAwesomeIcon` component and using it to render instead (since the documentation refers to an `icon` prop, rather than `name`).