### PR TITLE
Feature/comm info team fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "history": "^4.7.2",
     "lodash.debounce": "^4.0.8",
     "lodash.ismatch": "^4.4.0",
+    "lodash.orderby": "^4.6.0",
     "mixpanel-browser": "^2.38.0",
     "moment": "^2.29.2",
     "prop-types": "^15.6.1",

--- a/src/app/find/locationDetails/LocationDetails.jsx
+++ b/src/app/find/locationDetails/LocationDetails.jsx
@@ -290,8 +290,8 @@ class LocationDetails extends Component {
         />
         <Header size="medium" className="locationTitle">
           {location ? location.Organization.name : 'Loading...'}
-          {location && location.name && location.name.length > 0 && (
-            <div className="locationSubTitle">({location.name})</div>
+          {location && location.name && location.name.trim().length > 0 && (
+            <div className="locationSubTitle">({location.name.trim()})</div>
           )}
         </Header>
       </div>

--- a/src/app/find/locationDetails/ServiceSection.jsx
+++ b/src/app/find/locationDetails/ServiceSection.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import moment from 'moment';
+import orderBy from 'lodash.orderby';
 import PhoneLink from '../../../components/phoneLink';
 import ServiceOfferings from './ServiceOfferings';
 import ServiceRestrictions from './ServiceRestrictions';
@@ -35,7 +36,7 @@ const renderSchedule = (schedule) => {
     return `${dayNumberToName(start)} to ${dayNumberToName(end)}`;
   };
 
-  const orderedSchedule = schedule.sort(({ weekday: day1 }, { weekday: day2 }) => day1 - day2);
+  const orderedSchedule = orderBy(schedule, ['weekday', 'opens_at']);
 
   const daysGroupedByHours = orderedSchedule.reduce((grouped, day) => {
     const hoursString = formatHours(day.opens_at, day.closes_at);

--- a/src/app/team/locationForm/number/LocationNumberEdit.jsx
+++ b/src/app/team/locationForm/number/LocationNumberEdit.jsx
@@ -11,9 +11,13 @@ import Header from '../../../../components/header';
 import Input from '../../../../components/input';
 import Button from '../../../../components/button';
 
-const convertToPackagePhoneFormat = input => (input ? `${input.replace(/\./g, '')}` : '');
-const convertToOurFormat = input => (input ? `${input.slice(0, 3)}.${input.slice(3, 6)}.${input.slice(6)}` : '');
 const validPhoneNumberLength = input => input.length === 12;
+const convertToPackagePhoneFormat = input => (input ? `${input.replace(/\./g, '')}` : '');
+const convertToOurFormat = (input) => {
+  if (!input) return '';
+  const justDigits = input.replace(/[^\d]/g, '');
+  return `${justDigits.slice(0, 3)}.${justDigits.slice(3, 6)}.${justDigits.slice(6)}`;
+};
 
 class LocationNumberEdit extends Component {
   constructor(props) {
@@ -46,7 +50,7 @@ class LocationNumberEdit extends Component {
   onSubmit = (e) => {
     e.preventDefault();
 
-    const newPhoneNumber = this.state.newPhoneNumber ? this.state.newPhoneNumber : this.state.phoneNumber;
+    const newPhoneNumber = this.state.newPhoneNumber || convertToOurFormat(this.state.phoneNumber);
 
     if (!validPhoneNumberLength(newPhoneNumber)) {
       this.setState({ invalidNumber: true });

--- a/src/app/team/serviceForm/openingHours/ServiceOpeningHoursEdit.jsx
+++ b/src/app/team/serviceForm/openingHours/ServiceOpeningHoursEdit.jsx
@@ -94,6 +94,7 @@ class ServiceOpeningHours extends Component {
       active: getActive(props.value),
       weekdaysOpen: {},
       hours: props.value.filter(({ closed }) => !closed),
+      latestHoursEntered: null,
     };
   }
 
@@ -138,15 +139,18 @@ class ServiceOpeningHours extends Component {
 
   onChange = (field, hour, newValue) => {
     const idx = this.state.hours.indexOf(hour);
+    const newHoursAtIdx = {
+      ...this.state.hours[idx],
+      [field]: newValue,
+    };
+
     this.setState({
       hours: [
         ...this.state.hours.slice(0, idx),
-        {
-          ...this.state.hours[idx],
-          [field]: newValue,
-        },
+        newHoursAtIdx,
         ...this.state.hours.slice(idx + 1),
       ],
+      latestHoursEntered: newHoursAtIdx,
     });
   }
 
@@ -158,14 +162,15 @@ class ServiceOpeningHours extends Component {
   );
 
   addHour = (day) => {
+    const defaultHours = this.state.latestHoursEntered || {
+      opensAt: null,
+      closesAt: null,
+    };
+
     this.setState({
       hours: [
         ...this.state.hours,
-        {
-          weekday: day,
-          opensAt: null,
-          closesAt: null,
-        },
+        { ...defaultHours, weekday: day },
       ],
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11414,6 +11414,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.orderby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.orderby/-/lodash.orderby-4.6.0.tgz#e697f04ce5d78522f54d9338b32b81a3393e4eb3"
+  integrity sha512-T0rZxKmghOOf5YPnn8EY5iLYeWCpZq8G41FfqoVHH5QDTAFaghJRmAdLiadEDq+ztgM2q5PjA+Z1fOwGrLgmtg==
+
 lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"


### PR DESCRIPTION
A few small fixes/improvements based on feedback from the Community Information team's work, namely:

1. When saving a phone number in an old format without having made any changes to it (e.g. because you just added an extension/type), it'll be automatically re-formatted to our proper number format, instead of getting an error saying it's invalid
2. If a location name starts or ends with any spaces, they won't be shown in the parentheses in GoGetta
3. When adding service hours, once you add the hours for one of the days, any additional days you add will default to the same hours (so that when opening hours are the same for a bunch of days, you don't have to manually type them in over and over)
4. When there are multiple opening hour ranges for a given weekday, they'll be sorted in the right order (following Adam mentioning the issue with e.g. https://gogetta.nyc/find/location/670d087f-a834-4829-ac3f-9681c7be3db1)