### PR TITLE
Add service deletion to SSTT

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,6 +8,7 @@ export const GET_COMMENTS_RESPONSE = 'GET_COMMENTS_RESPONSE';
 export const GET_TAXONOMY_RESPONSE = 'GET_TAXONOMY_RESPONSE';
 export const OPTIMISTIC_UPDATE_LOCATION = 'OPTIMISTIC_UPDATE_LOCATION';
 export const OPTIMISTIC_UPDATE_SERVICE = 'OPTIMISTIC_UPDATE_SERVICE';
+export const OPTIMISTIC_DELETE_SERVICE = 'OPTIMISTIC_DELETE_SERVICE';
 export const OPTIMISTIC_POST_COMMENT = 'OPTIMISTIC_POST_COMMENT';
 export const UPDATE_LOCATION_ERROR = 'UPDATE_LOCATION_ERROR';
 export const UPDATE_SERVICE_ERROR = 'UPDATE_SERVICE_ERROR';
@@ -294,6 +295,22 @@ export const updateService = ({
       payload: { id: locationId, error: e },
     });
   });
+};
+
+export const deleteService = (id, { locationId }) => (dispatch) => {
+  dispatch({
+    type: OPTIMISTIC_DELETE_SERVICE,
+    payload: { serviceId: id, locationId },
+  });
+
+  return api.deleteService({ id })
+    .catch((e) => {
+      console.error('Error deleting service', e);
+      dispatch({
+        type: UPDATE_LOCATION_ERROR,
+        payload: { id: locationId, error: e },
+      });
+    });
 };
 
 export const updateLanguages = ({

--- a/src/app/team/service/categories/ServiceCategory.jsx
+++ b/src/app/team/service/categories/ServiceCategory.jsx
@@ -47,7 +47,7 @@ class ServiceCategory extends Component {
 
   isSubcategoryActive = (subcategory) => {
     const { currentServices, selected } = this.props;
-    return currentServices.subcategories[subcategory.id].hasExistingService
+    return currentServices.subcategories[subcategory.id].existingService
       || selected[subcategory.id];
   };
 
@@ -79,14 +79,13 @@ class ServiceCategory extends Component {
       key={subcategory.id}
       onClick={() => this.props.onSelectSubcategory(subcategory)}
       active={this.isSubcategoryActive(subcategory)}
-      disabled={subcategory.hasExistingService}
     >
       {subcategory.name}
     </Selector.Option>
   );
 
   renderExistingOtherService = service => (
-    <Selector.Option key={service.name} active disabled>
+    <Selector.Option key={service.name} active onClick={() => this.props.onDeleteService(service)}>
       {service.name}
     </Selector.Option>
   );

--- a/src/components/button/Button.css
+++ b/src/components/button/Button.css
@@ -43,9 +43,6 @@
 
 .Button-disabled {
   background-color: #5041ff;
-  border: 0 !important;
-  letter-spacing: 0.05rem;
-  font-size: 0.75rem
 }
 
 .Button-basic {

--- a/src/components/confirmationModal/ConfirmationModal.jsx
+++ b/src/components/confirmationModal/ConfirmationModal.jsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '../modal';
 import Header from '../header';
 import Button from '../button';
+import Input from '../input';
+
+const highRiskConfirmationText = 'yes';
 
 function ConfirmationModal({
   confirmText,
@@ -10,14 +13,35 @@ function ConfirmationModal({
   headerText,
   onConfirm,
   onCancel,
+  isHighRisk,
 }) {
+  const [inputText, setInputText] = useState('');
+  const canConfirm = () => !isHighRisk || inputText === highRiskConfirmationText;
+
   return (
     <Modal>
       <Header size="" className="m-4 flex-grow-1">
         { headerText }
+        {isHighRisk && (
+          <div className="pt-3">
+            {`If you're sure, type "${highRiskConfirmationText}" below,
+            then click "${confirmText}":`}
+          </div>
+        )}
       </Header>
       <div className="px-3">
-        <Button onClick={onConfirm} primary fluid>
+        {isHighRisk && (
+          <div className="pb-4" >
+            <Input
+              fluid
+              placeholder={`Type ${highRiskConfirmationText} if you're sure`}
+              autoComplete="off"
+              onChange={e => setInputText(e.target.value)}
+            />
+          </div>
+        )}
+
+        <Button onClick={() => canConfirm() && onConfirm()} primary fluid disabled={!canConfirm()}>
           { confirmText }
         </Button>
         <Button onClick={onCancel} primary basic fluid className="my-2">
@@ -26,7 +50,7 @@ function ConfirmationModal({
       </div>
     </Modal>
   );
-};
+}
 
 ConfirmationModal.propTypes = {
   confirmText: PropTypes.string,
@@ -34,12 +58,14 @@ ConfirmationModal.propTypes = {
   headerText: PropTypes.string,
   onConfirm: PropTypes.func,
   onCancel: PropTypes.func,
+  isHighRisk: PropTypes.bool,
 };
 
 ConfirmationModal.defaultProps = {
   confirmText: 'YES',
   cancelText: 'NO',
   headerText: 'Are you sure?',
+  isHighRisk: false,
 };
 
 export default ConfirmationModal;

--- a/src/reducers/locations.js
+++ b/src/reducers/locations.js
@@ -8,6 +8,7 @@ import {
   CREATE_PHONE_SUCCESS,
   OPTIMISTIC_UPDATE_ORGANIZATION,
   OPTIMISTIC_UPDATE_SERVICE,
+  OPTIMISTIC_DELETE_SERVICE,
   OPTIMISTIC_DELETE_PHONE,
 } from '../actions';
 import { DAYS } from '../Constants';
@@ -203,6 +204,17 @@ const locationsReducer = (state = {}, action) => {
         };
       }
       break;
+    case OPTIMISTIC_DELETE_SERVICE: {
+      const { locationId, serviceId } = action.payload;
+      const location = state[locationId];
+
+      const newServices = location.Services.filter(s => s.id !== serviceId);
+      return {
+        ...state,
+        [`last/${locationId}`]: location,
+        [locationId]: { ...location, Services: newServices },
+      };
+    }
     case OPTIMISTIC_UPDATE_ORGANIZATION:
       if (action.payload) {
         const {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -195,6 +195,10 @@ export const updateService = updateResource.bind(this, {
   pathPrefix: 'services',
   method: 'patch',
 });
+export const deleteService = updateResource.bind(this, {
+  pathPrefix: 'services',
+  method: 'delete',
+});
 
 export const getComments = ({ locationId }) =>
   axios


### PR DESCRIPTION
- Add "high risk" mode to ConfirmationModal component, for when
  accidentally clicking confirm would be bad so need to type "yes" too.
- Make it possible to uncheck already-existing services in the
  categories screen, deleting after requiring (high-risk) confirmation.
- Implement state management with optimistic updates and
  error handling for service deletion.
- Fix disabled button styling to not be so weird
  (as one can now see it enable/disable live in confirmation modal).