### PR TITLE
Integrate sentry for tracking errors on SSTT updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",
+    "@sentry/browser": "^7.114.0",
     "aws-amplify": "^4.2.8",
     "aws-amplify-react": "^2.0.7",
     "axios": "^0.21.3",

--- a/src/config.js
+++ b/src/config.js
@@ -14,4 +14,5 @@ export default {
   adminGroupName: process.env.REACT_APP_ADMIN_GROUP_NAME || 'StreetlivesAdmins',
   disableAuth: parseBoolean(process.env.REACT_APP_DISABLE_AUTH),
   mixpanelToken: process.env.REACT_APP_MIXPANEL_TOKEN || '8dd3b51f7a1de357a05e954495ae616f',
+  sentryDsn: 'https://f7a71e0f6282e1a79ba6f604080ec88e@o4507232810631168.ingest.us.sentry.io/4507235352313856',
 };

--- a/src/reducers/dataEntryErrorsReducer.js
+++ b/src/reducers/dataEntryErrorsReducer.js
@@ -1,35 +1,27 @@
+import * as Sentry from '@sentry/browser';
+
 import {
   UPDATE_LOCATION_ERROR,
   UPDATE_SERVICE_ERROR,
   DISMISS_DATA_ENTRY_ERRORS,
 } from '../actions';
-import * as Sentry from '@sentry/browser';
-
-Sentry.init({
-  dsn: "https://f7a71e0f6282e1a79ba6f604080ec88e@o4507232810631168.ingest.us.sentry.io/4507235352313856",
-  // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
-  tracePropagationTargets: ["localhost", /^https:\/\/(test.)?gogetta.nyc\/team/],
-  // Session Replay
-  replaysSessionSampleRate: 1, 
-  replaysOnErrorSampleRate: 1,
-});
 
 const locationErrorsReducer = (state = [], action) => {
+  const extra = {
+    response: {
+      payload: action.payload.error.response.data,
+      ...action.payload.error.response,
+    },
+  };
   switch (action.type) {
     case UPDATE_LOCATION_ERROR:
     case UPDATE_SERVICE_ERROR:
       if (!action.payload || !action.payload.error) {
         return state;
       }
-      const extra = {
-        response: {
-          payload: action.payload.error.response.data,
-          ...action.payload.error.response,
-        }
-      }
       Sentry.captureException(action.payload.error, {
         contexts: extra,
-        extra: extra,
+        extra,
       });
       return [action.payload.error, ...state];
 

--- a/src/reducers/dataEntryErrorsReducer.js
+++ b/src/reducers/dataEntryErrorsReducer.js
@@ -3,6 +3,16 @@ import {
   UPDATE_SERVICE_ERROR,
   DISMISS_DATA_ENTRY_ERRORS,
 } from '../actions';
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: "https://f7a71e0f6282e1a79ba6f604080ec88e@o4507232810631168.ingest.us.sentry.io/4507235352313856",
+  // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
+  tracePropagationTargets: ["localhost", /^https:\/\/(test.)?gogetta.nyc\/team/],
+  // Session Replay
+  replaysSessionSampleRate: 1, 
+  replaysOnErrorSampleRate: 1,
+});
 
 const locationErrorsReducer = (state = [], action) => {
   switch (action.type) {
@@ -11,7 +21,16 @@ const locationErrorsReducer = (state = [], action) => {
       if (!action.payload || !action.payload.error) {
         return state;
       }
-
+      const extra = {
+        response: {
+          payload: action.payload.error.response.data,
+          ...action.payload.error.response,
+        }
+      }
+      Sentry.captureException(action.payload.error, {
+        contexts: extra,
+        extra: extra,
+      });
       return [action.payload.error, ...state];
 
     case DISMISS_DATA_ENTRY_ERRORS:

--- a/src/reducers/dataEntryErrorsReducer.js
+++ b/src/reducers/dataEntryErrorsReducer.js
@@ -7,18 +7,18 @@ import {
 } from '../actions';
 
 const locationErrorsReducer = (state = [], action) => {
-  const extra = {
-    response: {
-      payload: action.payload.error.response.data,
-      ...action.payload.error.response,
-    },
-  };
   switch (action.type) {
     case UPDATE_LOCATION_ERROR:
     case UPDATE_SERVICE_ERROR:
       if (!action.payload || !action.payload.error) {
         return state;
       }
+      const extra = {
+        response: {
+          payload: action.payload.error.response.data,
+          ...action.payload.error.response,
+        },
+      };
       Sentry.captureException(action.payload.error, {
         contexts: extra,
         extra,

--- a/src/services/sentry.js
+++ b/src/services/sentry.js
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/browser';
+
+import config from '../config';
+
+Sentry.init({
+  // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
+  dsn: config.sentryDsn,
+  tracePropagationTargets: [
+    'localhost',
+    /^https:\/\/(((test)|(www)).)?gogetta.nyc\/team/,
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3432,6 +3432,88 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@sentry-internal/feedback@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-7.114.0.tgz#8a1c3d8bbd014c1823d30b9b1128eb244d357c3e"
+  integrity sha512-kUiLRUDZuh10QE9JbSVVLgqxFoD9eDPOzT0MmzlPuas8JlTmJuV4FtSANNcqctd5mBuLt2ebNXH0MhRMwyae4A==
+  dependencies:
+    "@sentry/core" "7.114.0"
+    "@sentry/types" "7.114.0"
+    "@sentry/utils" "7.114.0"
+
+"@sentry-internal/replay-canvas@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-7.114.0.tgz#b81e2c2ebec01c436ad6e687e563ba456e33b615"
+  integrity sha512-6rTiqmKi/FYtesdM2TM2U+rh6BytdPjLP65KTUodtxohJ+r/3m+termj2o4BhIYPE1YYOZNmbZfwebkuQPmWeg==
+  dependencies:
+    "@sentry/core" "7.114.0"
+    "@sentry/replay" "7.114.0"
+    "@sentry/types" "7.114.0"
+    "@sentry/utils" "7.114.0"
+
+"@sentry-internal/tracing@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.114.0.tgz#bdcd364f511e2de45db6e3004faf5685ca2e0f86"
+  integrity sha512-dOuvfJN7G+3YqLlUY4HIjyWHaRP8vbOgF+OsE5w2l7ZEn1rMAaUbPntAR8AF9GBA6j2zWNoSo8e7GjbJxVofSg==
+  dependencies:
+    "@sentry/core" "7.114.0"
+    "@sentry/types" "7.114.0"
+    "@sentry/utils" "7.114.0"
+
+"@sentry/browser@^7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.114.0.tgz#b0741bff89189d16c8b19f0775fe6e078147ec33"
+  integrity sha512-ijJ0vOEY6U9JJADVYGkUbLrAbpGSQgA4zV+KW3tcsBLX9M1jaWq4BV1PWHdzDPPDhy4OgfOjIfaMb5BSPn1U+g==
+  dependencies:
+    "@sentry-internal/feedback" "7.114.0"
+    "@sentry-internal/replay-canvas" "7.114.0"
+    "@sentry-internal/tracing" "7.114.0"
+    "@sentry/core" "7.114.0"
+    "@sentry/integrations" "7.114.0"
+    "@sentry/replay" "7.114.0"
+    "@sentry/types" "7.114.0"
+    "@sentry/utils" "7.114.0"
+
+"@sentry/core@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.114.0.tgz#3efe86b92a5379c44dfd0fd4685266b1a30fa898"
+  integrity sha512-YnanVlmulkjgZiVZ9BfY9k6I082n+C+LbZo52MTvx3FY6RE5iyiPMpaOh67oXEZRWcYQEGm+bKruRxLVP6RlbA==
+  dependencies:
+    "@sentry/types" "7.114.0"
+    "@sentry/utils" "7.114.0"
+
+"@sentry/integrations@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.114.0.tgz#baf249cfa9e359510f41e486a75bf184db18927d"
+  integrity sha512-BJIBWXGKeIH0ifd7goxOS29fBA8BkEgVVCahs6xIOXBjX1IRS6PmX0zYx/GP23nQTfhJiubv2XPzoYOlZZmDxg==
+  dependencies:
+    "@sentry/core" "7.114.0"
+    "@sentry/types" "7.114.0"
+    "@sentry/utils" "7.114.0"
+    localforage "^1.8.1"
+
+"@sentry/replay@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.114.0.tgz#f552e4803cacb233a2f5f2a4afbf5bed9052a744"
+  integrity sha512-UvEajoLIX9n2poeW3R4Ybz7D0FgCGXoFr/x/33rdUEMIdTypknxjJWxg6fJngIduzwrlrvWpvP8QiZXczYQy2Q==
+  dependencies:
+    "@sentry-internal/tracing" "7.114.0"
+    "@sentry/core" "7.114.0"
+    "@sentry/types" "7.114.0"
+    "@sentry/utils" "7.114.0"
+
+"@sentry/types@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.114.0.tgz#ab8009d5f6df23b7342121083bed34ee2452e856"
+  integrity sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==
+
+"@sentry/utils@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.114.0.tgz#59d30a79f4acff3c9268de0b345f0bcbc6335112"
+  integrity sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==
+  dependencies:
+    "@sentry/types" "7.114.0"
+
 "@storybook/addon-actions@3.4.12", "@storybook/addon-actions@^3.3.15":
   version "3.4.12"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.4.12.tgz#ff6cbaf563c3cb5d648d6a35f66cfa50ced49bf4"
@@ -9788,6 +9870,11 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 immer@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
@@ -11242,6 +11329,13 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -11316,6 +11410,13 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+localforage@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Sentry integration is working well.

Sentry dashboard reports request and response:

![image](https://github.com/streetlives/streetlives-web/assets/586962/bebfbe22-33c8-4280-af3c-12e7dcb27c21)

Publish notification to Slack:

![image](https://github.com/streetlives/streetlives-web/assets/586962/49b217a3-7158-42d6-82f6-7611216b8fef)
