### PR TITLE
[codex] add phone contact method handling

### DIFF
--- a/src/app/team/locationForm/number/LocationNumberEdit.jsx
+++ b/src/app/team/locationForm/number/LocationNumberEdit.jsx
@@ -1,22 +1,33 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
-import PhoneInput from 'react-phone-input-2';
-import 'react-phone-input-2/lib/style.css';
 
 import { getPhoneNumber } from '../../../../selectors/location';
 import { updatePhone, createPhone } from '../../../../actions';
+import {
+  PHONE_USE,
+  PHONE_USE_OPTIONS,
+  isValidPhoneNumberForUse,
+  normalizePhoneDigits,
+  normalizePhoneUse,
+  phoneCanHaveExtension,
+  phoneUseToTypeLabel,
+} from '../../../../utils/phones';
 
 import Header from '../../../../components/header';
 import Input from '../../../../components/input';
 import Button from '../../../../components/button';
 
-const validPhoneNumberLength = input => input.length === 12;
-const convertToPackagePhoneFormat = input => (input ? `${input.replace(/\./g, '')}` : '');
-const convertToOurFormat = (input) => {
-  if (!input) return '';
-  const justDigits = input.replace(/[^\d]/g, '');
-  return `${justDigits.slice(0, 3)}.${justDigits.slice(3, 6)}.${justDigits.slice(6)}`;
+const getPhoneLabel = (phone) => {
+  const phoneUse = normalizePhoneUse(phone && phone.type);
+
+  if (phoneUse === PHONE_USE.PHONE) {
+    return phone && phone.type && phone.type !== phoneUseToTypeLabel(PHONE_USE.PHONE)
+      ? phone.type
+      : '';
+  }
+
+  return '';
 };
 
 class LocationNumberEdit extends Component {
@@ -25,18 +36,33 @@ class LocationNumberEdit extends Component {
     this.state = {
       extension: '',
       type: '',
+      phoneUse: PHONE_USE.PHONE,
       phoneNumber: '',
       newPhoneNumber: '',
+      loadedPhoneId: null,
+      loadedPhoneNumber: null,
       invalidNumber: false,
     };
   }
 
   static getDerivedStateFromProps(props, state) {
-    if (props.phone && props.phone.number !== state.phoneNumber) {
+    if (
+      props.phone &&
+      (
+        props.phone.id !== state.loadedPhoneId ||
+        props.phone.number !== state.loadedPhoneNumber
+      )
+    ) {
+      const phoneUse = normalizePhoneUse(props.phone.type);
+
       return {
-        extension: (props.phone && props.phone.extension) || '',
-        type: (props.phone && props.phone.type) || '',
-        phoneNumber: props.phone && props.phone.number,
+        extension: phoneCanHaveExtension(phoneUse) ? props.phone.extension || '' : '',
+        type: getPhoneLabel(props.phone),
+        phoneUse,
+        phoneNumber: normalizePhoneDigits(props.phone.number),
+        newPhoneNumber: '',
+        loadedPhoneId: props.phone.id,
+        loadedPhoneNumber: props.phone.number,
       };
     }
 
@@ -50,21 +76,23 @@ class LocationNumberEdit extends Component {
   onSubmit = (e) => {
     e.preventDefault();
 
-    const newPhoneNumber = this.state.newPhoneNumber || convertToOurFormat(this.state.phoneNumber);
+    const phoneNumberInput = this.state.newPhoneNumber || this.state.phoneNumber;
+    const newPhoneNumber = normalizePhoneDigits(phoneNumberInput);
 
-    if (!validPhoneNumberLength(newPhoneNumber)) {
+    if (!isValidPhoneNumberForUse(newPhoneNumber, this.state.phoneUse)) {
       this.setState({ invalidNumber: true });
       return;
     }
 
+    const canHaveExtension = phoneCanHaveExtension(this.state.phoneUse);
+    const type = this.state.phoneUse === PHONE_USE.PHONE
+      ? this.state.type || phoneUseToTypeLabel(PHONE_USE.PHONE)
+      : phoneUseToTypeLabel(this.state.phoneUse);
     const params = {
       number: newPhoneNumber,
-      extension: parseInt(this.state.extension, 10) || null,
+      extension: canHaveExtension ? parseInt(this.state.extension, 10) || null : null,
+      type,
     };
-
-    if (this.state.type) {
-      params.type = this.state.type;
-    }
 
     this.props.updateValue(
       params,
@@ -75,43 +103,77 @@ class LocationNumberEdit extends Component {
   }
 
   render() {
+    const canHaveExtension = phoneCanHaveExtension(this.state.phoneUse);
+    const phoneNumber = this.state.newPhoneNumber || this.state.phoneNumber;
+
     return (
       <form
         className="container"
         onSubmit={this.onSubmit}
       >
         <Header>What&apos;s this location&apos;s phone number?</Header>
+        <select
+          className="Input Input-fluid mb-3"
+          value={this.state.phoneUse}
+          onChange={(e) => {
+            const phoneUse = e.target.value;
+            this.setState({
+              phoneUse,
+              extension: phoneCanHaveExtension(phoneUse) ? this.state.extension : '',
+              invalidNumber: false,
+            });
+          }}
+        >
+          {PHONE_USE_OPTIONS.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
         <div className="phone-wrapper">
-          <PhoneInput
-            country="us"
-            disableCountryCode
-            disableDropdown
-            onlyCountries={['us']}
-            value={convertToPackagePhoneFormat(this.state.phoneNumber)}
-            placeholder="(111) 111-1111"
-            limitMaxLength
-            onChange={(newNumber) => {
-              this.setState({ newPhoneNumber: convertToOurFormat(newNumber) });
-            }}
-          />
-          &nbsp;-&nbsp;
           <Input
             onFocus={this.props.onInputFocus}
             onBlur={this.props.onInputBlur}
             type="tel"
-            size="4"
-            value={this.state.extension}
-            onChange={e => this.setState({ extension: e.target.value })}
+            value={phoneNumber}
+            placeholder="7185551212 or 988"
+            fluid
+            onChange={(e) => {
+              this.setState({
+                newPhoneNumber: normalizePhoneDigits(e.target.value),
+                invalidNumber: false,
+              });
+            }}
           />
+          {canHaveExtension && (
+            <>
+              &nbsp;-&nbsp;
+              <Input
+                onFocus={this.props.onInputFocus}
+                onBlur={this.props.onInputBlur}
+                type="tel"
+                size="4"
+                value={this.state.extension}
+                placeholder="Ext"
+                onChange={e => this.setState({ extension: e.target.value })}
+              />
+            </>
+          )}
         </div>
-        <Input
-          placeholder="Type (e.g. Main Office, Hotline, Spanish, etc)"
-          fluid
-          value={this.state.type}
-          onChange={e => this.setState({ type: e.target.value })}
-        />
+        {this.state.phoneUse === PHONE_USE.PHONE && (
+          <Input
+            placeholder="Label (e.g. Main Office, Hotline, Spanish, etc)"
+            fluid
+            value={this.state.type}
+            onChange={e => this.setState({ type: e.target.value })}
+          />
+        )}
         <div>
-          {this.state.invalidNumber ? <h5 className="invalid-number-warning">Please enter a valid phone number</h5> : ''}
+          {this.state.invalidNumber ? (
+            <h5 className="invalid-number-warning">
+              Please enter 3 to 10 digits. WhatsApp numbers need 10 digits.
+            </h5>
+          ) : ''}
         </div>
         <div>
           <input type="submit" className="Button Button-primary mt-3" value="OK" />&nbsp;

--- a/src/app/team/locationForm/number/LocationNumberView.jsx
+++ b/src/app/team/locationForm/number/LocationNumberView.jsx
@@ -10,11 +10,12 @@ import Button from '../../../../components/button';
 import Icon from '../../../../components/icon';
 import ConfirmationOptions from '../../../../components/form/ConfirmationOptions';
 import ConfirmationModal from '../../../../components/confirmationModal';
+import { formatPhoneNumberForDisplay } from '../../../../utils/phones';
 
 const formatPhoneNumber = phone =>
-  `${phone.number.replace(/\./g, '-')}${
-    phone.extension ? ` ext. ${phone.extension}` : ''
-  }`;
+  formatPhoneNumberForDisplay(phone.number, phone.extension, phone.type);
+
+const formatPhoneType = phone => (phone.type === 'Phone' ? '' : phone.type);
 
 class LocationNumberView extends Component {
   constructor(props) {
@@ -77,7 +78,11 @@ class LocationNumberView extends Component {
     const onConfirmWithPatch = () => {
       if (phones && phones.length > 0) {
         const phone = phones[0];
-        patchPhone(phone.id, { number: phone.number, type: phone.type, extension: phone.extension });
+        patchPhone(phone.id, {
+          number: phone.number,
+          type: phone.type,
+          extension: phone.extension,
+        });
       }
       onConfirm();
     };
@@ -112,7 +117,7 @@ class LocationNumberView extends Component {
                   </button>
                 }
                 <p className="PhoneNumber-Number">{ formatPhoneNumber(phone) }</p>
-                <p className="PhoneNumber-Type">{phone.type}</p>
+                <p className="PhoneNumber-Type">{formatPhoneType(phone)}</p>
 
                 { isEditing &&
                   <Button

--- a/src/components/phoneLink/PhoneLink.jsx
+++ b/src/components/phoneLink/PhoneLink.jsx
@@ -1,18 +1,72 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {
+  formatPhoneForDisplay,
+  getPhoneHref,
+} from '../../utils/phones';
 
-function PhoneLink({ number, className }) {
-  // TODO: Handle other fields (extensions and such).
-  const phoneLink = `tel:${number}`;
+function PhoneLink({
+  number,
+  extension,
+  type,
+  description,
+  className,
+}) {
+  const phoneLink = getPhoneHref({ number, extension, type });
+  const displayPhone = formatPhoneForDisplay({
+    number,
+    extension,
+    type,
+    description,
+  });
+
+  if (!phoneLink) {
+    return (
+      <span className={className}>
+        {displayPhone}
+      </span>
+    );
+  }
+
+  if (phoneLink.startsWith('https://')) {
+    return (
+      <a
+        className={className}
+        href={phoneLink}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {displayPhone}
+      </a>
+    );
+  }
+
   return (
-    <a className={className} href={phoneLink}>
-      {number}
+    <a
+      className={className}
+      href={phoneLink}
+    >
+      {displayPhone}
     </a>
   );
 }
 
 PhoneLink.propTypes = {
   number: PropTypes.string.isRequired,
+  extension: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  type: PropTypes.string,
+  description: PropTypes.string,
+  className: PropTypes.string,
+};
+
+PhoneLink.defaultProps = {
+  extension: null,
+  type: null,
+  description: null,
+  className: null,
 };
 
 export default PhoneLink;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,10 @@
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+const unitTestRun = process.argv.some(arg => arg.includes('src/utils'));
 
-configure({ adapter: new Adapter() });
+if (!unitTestRun) {
+  // eslint-disable-next-line global-require
+  const { configure } = require('enzyme');
+  // eslint-disable-next-line global-require
+  const Adapter = require('enzyme-adapter-react-16');
+
+  configure({ adapter: new Adapter() });
+}

--- a/src/utils/phones.js
+++ b/src/utils/phones.js
@@ -1,0 +1,131 @@
+export const PHONE_USE = {
+  PHONE: 'phone',
+  SMS: 'sms',
+  WHATSAPP: 'whatsapp',
+  FAX: 'fax',
+};
+
+export const PHONE_USE_OPTIONS = [
+  { value: PHONE_USE.PHONE, label: 'Phone' },
+  { value: PHONE_USE.SMS, label: 'Text only' },
+  { value: PHONE_USE.WHATSAPP, label: 'WhatsApp' },
+  { value: PHONE_USE.FAX, label: 'Fax' },
+];
+
+const MIN_PHONE_DIGITS = 3;
+const MAX_PHONE_DIGITS = 10;
+const PHONE_USE_LABELS = {
+  [PHONE_USE.PHONE]: 'Phone',
+  [PHONE_USE.SMS]: 'Text',
+  [PHONE_USE.WHATSAPP]: 'WhatsApp',
+  [PHONE_USE.FAX]: 'Fax',
+};
+
+export function normalizePhoneUse(type) {
+  const normalizedType = `${type || ''}`.toLowerCase().replace(/[\s_-]+/g, '');
+
+  if (normalizedType.includes('whatsapp')) {
+    return PHONE_USE.WHATSAPP;
+  }
+
+  if (normalizedType.includes('sms') || normalizedType.includes('text')) {
+    return PHONE_USE.SMS;
+  }
+
+  if (normalizedType.includes('fax')) {
+    return PHONE_USE.FAX;
+  }
+
+  return PHONE_USE.PHONE;
+}
+
+export function phoneCanHaveExtension(type) {
+  return normalizePhoneUse(type) === PHONE_USE.PHONE;
+}
+
+export function phoneUseToTypeLabel(phoneUse) {
+  return PHONE_USE_LABELS[normalizePhoneUse(phoneUse)];
+}
+
+export function normalizePhoneDigits(number) {
+  const digits = `${number || ''}`.replace(/\D/g, '');
+
+  if (digits.length === 11 && digits.startsWith('1')) {
+    return digits.slice(1);
+  }
+
+  return digits;
+}
+
+export function isValidPhoneNumberForUse(number, type) {
+  const digits = normalizePhoneDigits(number);
+  const phoneUse = normalizePhoneUse(type);
+
+  if (digits.length < MIN_PHONE_DIGITS || digits.length > MAX_PHONE_DIGITS) {
+    return false;
+  }
+
+  return phoneUse !== PHONE_USE.WHATSAPP || digits.length === MAX_PHONE_DIGITS;
+}
+
+export function formatPhoneNumberForDisplay(number, extension, type) {
+  const digits = normalizePhoneDigits(number);
+  const canHaveExtension = phoneCanHaveExtension(type);
+  const extensionText = canHaveExtension && extension ? ` ext. ${extension}` : '';
+
+  if (digits.length === MAX_PHONE_DIGITS) {
+    return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}${extensionText}`;
+  }
+
+  if (digits.length === 7) {
+    return `${digits.slice(0, 3)}-${digits.slice(3)}${extensionText}`;
+  }
+
+  return `${digits || number}${extensionText}`;
+}
+
+function getDialableNumber(number) {
+  const digits = normalizePhoneDigits(number);
+  return digits.length === MAX_PHONE_DIGITS ? `+1${digits}` : digits;
+}
+
+export function getPhoneHref({ number, extension, type }) {
+  const phoneUse = normalizePhoneUse(type);
+  const digits = normalizePhoneDigits(number);
+
+  if (!isValidPhoneNumberForUse(digits, phoneUse) || phoneUse === PHONE_USE.FAX) {
+    return null;
+  }
+
+  if (phoneUse === PHONE_USE.WHATSAPP) {
+    return `https://wa.me/1${digits}`;
+  }
+
+  if (phoneUse === PHONE_USE.SMS) {
+    return `sms:${getDialableNumber(digits)}`;
+  }
+
+  return `tel:${getDialableNumber(digits)}${
+    extension && phoneCanHaveExtension(phoneUse) ? `;ext=${extension}` : ''
+  }`;
+}
+
+export function formatPhoneForDisplay({
+  number,
+  extension,
+  type,
+  description,
+}) {
+  const phoneUse = normalizePhoneUse(type);
+  const methodLabel = phoneUse === PHONE_USE.PHONE
+    ? null
+    : phoneUseToTypeLabel(phoneUse);
+  const customType = type === phoneUseToTypeLabel(PHONE_USE.PHONE) ? null : type;
+  const customLabel = phoneUse === PHONE_USE.PHONE ? (description || customType) : null;
+  const label = methodLabel || customLabel;
+  const detail = methodLabel && description ? ` (${description})` : '';
+
+  return `${label ? `${label}: ` : ''}${
+    formatPhoneNumberForDisplay(number, extension, phoneUse)
+  }${detail}`;
+}

--- a/src/utils/phones.test.js
+++ b/src/utils/phones.test.js
@@ -1,0 +1,35 @@
+import {
+  formatPhoneForDisplay,
+  getPhoneHref,
+  isValidPhoneNumberForUse,
+  normalizePhoneDigits,
+} from './phones';
+
+describe('phone utilities', () => {
+  it('normalizes punctuation and leading US country codes', () => {
+    expect(normalizePhoneDigits('+1 (212) 555-1212')).toBe('2125551212');
+  });
+
+  it('allows short phone and text numbers', () => {
+    expect(isValidPhoneNumberForUse('988', 'Phone')).toBe(true);
+    expect(isValidPhoneNumberForUse('12345', 'Text only')).toBe(true);
+  });
+
+  it('links text numbers with sms and phone numbers with tel', () => {
+    expect(getPhoneHref({ number: '12345', type: 'Text only' })).toBe('sms:12345');
+    expect(getPhoneHref({ number: '2125551212', extension: 123, type: 'Phone' }))
+      .toBe('tel:+12125551212;ext=123');
+  });
+
+  it('links WhatsApp numbers externally without a plus sign in the path', () => {
+    expect(getPhoneHref({ number: '2125551212', type: 'WhatsApp' }))
+      .toBe('https://wa.me/12125551212');
+    expect(getPhoneHref({ number: '12345', type: 'WhatsApp' })).toBe(null);
+  });
+
+  it('does not hyperlink fax numbers', () => {
+    expect(getPhoneHref({ number: '2125551212', type: 'Fax' })).toBe(null);
+    expect(formatPhoneForDisplay({ number: '2125551212', type: 'Fax' }))
+      .toBe('Fax: 212-555-1212');
+  });
+});


### PR DESCRIPTION
## Summary
- replace dotted phone entry with digits-only input that accepts 3-10 digit short numbers
- add a contact method selector for phone, text only, WhatsApp, and fax
- hide/clear extensions for text, WhatsApp, and fax numbers
- render public phone links as tel, sms, WhatsApp `wa.me`, or plain fax text as appropriate
- add focused utility tests and allow utility-only test runs to bypass legacy Enzyme setup

## Validation
- `npx eslint src/utils/phones.js src/utils/phones.test.js src/setupTests.js src/components/phoneLink/PhoneLink.jsx src/app/team/locationForm/number/LocationNumberEdit.jsx src/app/team/locationForm/number/LocationNumberView.jsx`
- `CI=true npm test -- --runTestsByPath src/utils/phones.test.js`

Part of the phone contact-method work alongside `streetlives/yourpeer.nyc#579`.