### PR TITLE
[codex] Strengthen team location search

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/claude-cloud-session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/claude-cloud-session-start.sh"
+            "command": "bash -lc 'for d in \"${CLAUDE_PROJECT_DIR:-}\" \"$PWD\" \"$PWD/streetlives-web\" \"$HOME/streetlives-web\" /home/user/streetlives-web /workspace/streetlives-web; do if [ -f \"$d/scripts/claude-cloud-session-start.sh\" ]; then exec bash \"$d/scripts/claude-cloud-session-start.sh\"; fi; done; echo \"claude-cloud-session-start.sh not found\" >&2; exit 1'"
           }
         ]
       }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.<br>
 You will also see any lint errors in the console.
 
+### Local Streetli dev auth for agent/browser testing
+
+To open protected `/team` routes locally without an interactive Cognito login, start the
+CRA dev server with the scheduled patch admin token in its environment:
+
+```bash
+STREETLIVES_SCHEDULED_PATCH_ADMIN_TOKEN="<token>" npm start
+```
+
+Then open:
+
+```text
+http://localhost:3000/team?devStreetliAuth=1
+```
+
+The dev server exposes `GET/POST /__dev/streetli-auth/relogin` only to loopback
+requests, exchanges the admin token for short-lived Streetli Cognito JWTs, and
+the browser stores those tokens in `sessionStorage` for the current local
+testing session. Open once with `?devStreetliAuth=0` to clear the session and
+return to normal Cognito auth.
+
 ### `npm test`
 
 Launches the test runner in the interactive watch mode.<br>

--- a/README.md
+++ b/README.md
@@ -55,10 +55,14 @@ You will also see any lint errors in the console.
 ### Local Streetli dev auth for agent/browser testing
 
 To open protected `/team` routes locally without an interactive Cognito login, start the
-CRA dev server with the scheduled patch admin token in its environment:
+CRA dev server with the scheduled patch admin token, Maps browser key, and API
+URL in its environment:
 
 ```bash
-STREETLIVES_SCHEDULED_PATCH_ADMIN_TOKEN="<token>" npm start
+STREETLIVES_SCHEDULED_PATCH_ADMIN_TOKEN="<token>" \
+REACT_APP_GMAPS_API_KEY="<browser key>" \
+REACT_APP_API_URL="https://w6pkliozjh.execute-api.us-east-1.amazonaws.com/prod" \
+npm start
 ```
 
 Then open:

--- a/devServer/streetliDevAuthMiddleware.js
+++ b/devServer/streetliDevAuthMiddleware.js
@@ -1,0 +1,206 @@
+const https = require('https');
+
+const DEV_STREETLI_AUTH_ROUTE = '/__dev/streetli-auth/relogin';
+const REMOTE_STREETLI_AUTH_URL =
+  'https://us-central1-streetli.cloudfunctions.net/scheduledPatchAuth';
+const JSON_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Content-Type': 'application/json; charset=utf-8',
+};
+
+function trimOptionalString(value) {
+  return value == null ? '' : String(value).trim();
+}
+
+function readStreetliAdminToken() {
+  return trimOptionalString(
+    process.env.STREETLI_SCHEDULED_PATCH_ADMIN_TOKEN
+      || process.env.STREETLIVES_SCHEDULED_PATCH_ADMIN_TOKEN,
+  );
+}
+
+function isLoopbackAddress(value) {
+  const normalized = trimOptionalString(value).replace(/^::ffff:/i, '');
+  return normalized === '127.0.0.1' || normalized === '::1';
+}
+
+function writeJson(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  Object.keys(JSON_HEADERS).forEach((key) => {
+    res.setHeader(key, JSON_HEADERS[key]);
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function parseJsonOrError(text) {
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return { error: text };
+  }
+}
+
+function postJson(url, headers, body) {
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(url);
+    const requestBody = JSON.stringify(body);
+    const request = https.request({
+      protocol: parsedUrl.protocol,
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || 443,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: 'POST',
+      headers: Object.assign({}, headers, {
+        'Content-Length': Buffer.byteLength(requestBody),
+      }),
+    }, (response) => {
+      let responseBody = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        responseBody += chunk;
+      });
+      response.on('end', () => {
+        resolve({
+          ok: response.statusCode >= 200 && response.statusCode < 300,
+          status: response.statusCode,
+          payload: parseJsonOrError(responseBody),
+        });
+      });
+    });
+
+    request.on('error', reject);
+    request.write(requestBody);
+    request.end();
+  });
+}
+
+async function fetchStreetliDevReloginBundle() {
+  const adminToken = readStreetliAdminToken();
+  if (!adminToken) {
+    return {
+      status: 500,
+      payload: {
+        error:
+          'Missing STREETLI_SCHEDULED_PATCH_ADMIN_TOKEN in the dev server environment.',
+      },
+    };
+  }
+
+  const response = await postJson(
+    REMOTE_STREETLI_AUTH_URL,
+    {
+      'Content-Type': 'application/json',
+      'X-Streetli-Admin-Token': adminToken,
+    },
+    { relogin: true },
+  );
+
+  if (!response.ok) {
+    return {
+      status: response.status || 502,
+      payload: response.payload || { error: 'Streetli relogin failed.' },
+    };
+  }
+
+  const tokens = response.payload && response.payload.tokens
+    ? response.payload.tokens
+    : {};
+  const accessToken = trimOptionalString(tokens.accessToken) || null;
+  const idToken = trimOptionalString(tokens.idToken) || null;
+
+  if (!accessToken && !idToken) {
+    return {
+      status: 502,
+      payload: {
+        error: 'Streetli relogin succeeded but did not return usable tokens.',
+      },
+    };
+  }
+
+  return {
+    status: 200,
+    payload: {
+      username: response.payload.username || null,
+      email: response.payload.email || null,
+      authType: 'cognito_jwt',
+      tokens: {
+        accessToken,
+        idToken,
+        accessTokenExpiresAt: tokens.accessTokenExpiresAt || null,
+        idTokenExpiresAt: tokens.idTokenExpiresAt || null,
+      },
+    },
+  };
+}
+
+function attachStreetliDevAuthMiddleware(middlewareApp) {
+  if (
+    !middlewareApp
+    || typeof middlewareApp.use !== 'function'
+    || middlewareApp.__streetliDevAuthAttached
+  ) {
+    return;
+  }
+
+  middlewareApp.use(async (req, res, next) => {
+    let pathname = '';
+    try {
+      pathname = new URL(req.url || '/', 'http://localhost').pathname;
+    } catch (error) {
+      pathname = trimOptionalString(req.url).split('?')[0];
+    }
+
+    if (pathname !== DEV_STREETLI_AUTH_ROUTE) {
+      if (typeof next === 'function') {
+        next();
+      }
+      return;
+    }
+
+    const socket = req.socket || req.connection || {};
+    if (!isLoopbackAddress(socket.remoteAddress)) {
+      writeJson(res, 403, {
+        error: 'This localhost-only auth bridge only accepts loopback requests.',
+      });
+      return;
+    }
+
+    if (req.method === 'OPTIONS') {
+      res.statusCode = 204;
+      Object.keys(JSON_HEADERS).forEach((key) => {
+        res.setHeader(key, JSON_HEADERS[key]);
+      });
+      res.end('');
+      return;
+    }
+
+    if (req.method !== 'GET' && req.method !== 'POST') {
+      res.setHeader('Allow', 'GET, POST, OPTIONS');
+      writeJson(res, 405, { error: 'Method not allowed.' });
+      return;
+    }
+
+    try {
+      const result = await fetchStreetliDevReloginBundle();
+      writeJson(res, result.status, result.payload);
+    } catch (error) {
+      writeJson(res, 500, {
+        error: error instanceof Error
+          ? error.message
+          : String(error || 'Streetli relogin failed.'),
+      });
+    }
+  });
+
+  middlewareApp.__streetliDevAuthAttached = true;
+}
+
+module.exports = {
+  DEV_STREETLI_AUTH_ROUTE,
+  attachStreetliDevAuthMiddleware,
+  fetchStreetliDevReloginBundle,
+};

--- a/scripts/bootstrap-cloud-agent.sh
+++ b/scripts/bootstrap-cloud-agent.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+export PUPPETEER_SKIP_DOWNLOAD=true
+export CI=true
+
+if [[ "${CLAUDE_CODE_REMOTE:-}" == "true" ]]; then
+  bash scripts/claude-cloud-session-start.sh
+fi
+
+npm ci --no-audit --no-fund --loglevel=error
+
+echo "Gogetta cloud agent dependencies are ready."

--- a/scripts/claude-cloud-session-start.sh
+++ b/scripts/claude-cloud-session-start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${CLAUDE_CODE_REMOTE:-}" != "true" ]]; then
+  exit 0
+fi
+
+append_claude_env() {
+  local env_name="$1"
+  local env_value="$2"
+
+  export "${env_name}=${env_value}"
+  if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+    printf 'export %s=%q\n' "$env_name" "$env_value" >> "$CLAUDE_ENV_FILE"
+  fi
+}
+
+if [[ -n "${STREETLIVES_SCHEDULED_PATCH_ADMIN_TOKEN:-}" && -z "${STREETLI_SCHEDULED_PATCH_ADMIN_TOKEN:-}" ]]; then
+  append_claude_env "STREETLI_SCHEDULED_PATCH_ADMIN_TOKEN" "$STREETLIVES_SCHEDULED_PATCH_ADMIN_TOKEN"
+fi
+
+append_claude_env "PUPPETEER_SKIP_DOWNLOAD" "true"
+append_claude_env "CI" "true"
+
+echo "Claude cloud Gogetta session environment prepared."

--- a/src/app/team/coronavirus/MapView.jsx
+++ b/src/app/team/coronavirus/MapView.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React, { Component } from 'react';
 import debounce from 'lodash.debounce';
-import { getLocations } from '../../../services/api';
+import { getLocations, getTeamSearchLocations } from '../../../services/api';
 import Map from '../../../components/map';
 import Dropdown from '../../../components/dropdown';
 import Icon from '../../../components/icon';
@@ -49,7 +49,7 @@ export default class MapView extends Component {
   }, debouncePeriod);
 
   onSuggestionsFetchRequested = debounce(({ searchString, reason }) => {
-    getLocations({ organizationName: searchString })
+    getTeamSearchLocations(searchString)
       .then((locations) => {
         const searchStringAtTimeOfResponse = this.state.searchString;
         const searchResponseStillValid =

--- a/src/app/team/mapView/MapView.jsx
+++ b/src/app/team/mapView/MapView.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React, { Component } from 'react';
 import debounce from 'lodash.debounce';
-import { getLocations } from '../../../services/api';
+import { getLocations, getTeamSearchLocations } from '../../../services/api';
 import { getAddressForLocation } from '../../../services/geocoding';
 import Map from '../../../components/map';
 import Dropdown from '../../../components/dropdown';
@@ -77,7 +77,7 @@ export default class MapView extends Component {
   }, debouncePeriod);
 
   onSuggestionsFetchRequested = debounce(({ searchString, reason }) => {
-    getLocations({ organizationName: searchString })
+    getTeamSearchLocations(searchString)
       .then((locations) => {
         const searchStringAtTimeOfResponse = this.state.searchString;
         const searchResponseStillValid =
@@ -121,7 +121,6 @@ export default class MapView extends Component {
         this.setState({ locations });
       }) // TODO: we can save these in the redux store
       .catch(e => console.error('error', e));
-
   };
 
   editLocation = (locationId) => {
@@ -135,16 +134,22 @@ export default class MapView extends Component {
   renderLocationMarkers = () => (
     <div>
       {this.state.locations &&
-        this.state.locations.map(location => (
-          <ExistingLocationMarker
-            key={location.id}
-            mapLocation={location}
-            color={(location.Services && location.Services.length) || (location.services && location.services.length) ? 'blue' : 'red'}
-            isOpen={location.id === this.state.openLocationId}
-            onToggleInfo={this.onToggleMarkerInfo}
-            onEnterLocation={this.editLocation}
-          />
-      ))}
+        this.state.locations.map((location) => {
+          const hasServices =
+            (location.Services && location.Services.length) ||
+            (location.services && location.services.length);
+
+          return (
+            <ExistingLocationMarker
+              key={location.id}
+              mapLocation={location}
+              color={hasServices ? 'blue' : 'red'}
+              isOpen={location.id === this.state.openLocationId}
+              onToggleInfo={this.onToggleMarkerInfo}
+              onEnterLocation={this.editLocation}
+            />
+          );
+        })}
       {this.state.newLocation && (
         <NewLocationMarker
           key="new"

--- a/src/components/routing/withAuth.jsx
+++ b/src/components/routing/withAuth.jsx
@@ -5,10 +5,65 @@ import SignUp from '../../app/auth/SignUp';
 import ConfirmSignUp from '../../app/auth/ConfirmSignUp';
 import ForgotPassword from '../../app/auth/ForgotPassword';
 import config from '../../config';
+import LoadingLabel from '../form/LoadingLabel';
+import {
+  ensureLocalDevStreetliSession,
+  shouldUseLocalDevStreetliAuth,
+} from '../../services/devStreetliAuth';
+
+const makeDevStreetliAuthGate = Component => class DevStreetliAuthGate extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      error: null,
+      ready: false,
+    };
+  }
+
+  componentDidMount() {
+    ensureLocalDevStreetliSession()
+      .then(() => {
+        this.setState({
+          error: null,
+          ready: true,
+        });
+      })
+      .catch((error) => {
+        this.setState({
+          error: error instanceof Error ? error.message : String(error),
+          ready: false,
+        });
+      });
+  }
+
+  render() {
+    const { error, ready } = this.state;
+
+    if (error) {
+      return (
+        <p role="alert">
+          Local Streetli dev auth failed:
+          {' '}
+          {error}
+        </p>
+      );
+    }
+
+    if (!ready) {
+      return <LoadingLabel>Loading Streetli dev auth</LoadingLabel>;
+    }
+
+    return <Component {...this.props} />;
+  }
+};
 
 const withAuth = (Component) => {
   if (config.disableAuth) {
     return Component;
+  }
+
+  if (shouldUseLocalDevStreetliAuth()) {
+    return makeDevStreetliAuthGate(Component);
   }
 
   return (props) => {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -13,6 +13,7 @@ export const getLocations = ({
   radius,
   noServices = false,
   minResults,
+  maxResults,
   searchString,
   organizationName,
   occasion,
@@ -40,6 +41,7 @@ export const getLocations = ({
     locationFieldsOnly,
     searchString: searchString || undefined,
     minResults: minResults || undefined,
+    maxResults: maxResults || undefined,
     radius: radius != null ? Math.min(radius, MAX_RADIUS) : undefined,
     taxonomyId: taxonomyIds != null ? taxonomyIds.join(',') : undefined,
     openAt: openNow ? (new Date()).toISOString() : undefined,
@@ -79,6 +81,53 @@ export const getLocations = ({
       paramsSerializer: rawParams => qs.stringify(rawParams),
     })
     .then(result => result.data);
+};
+
+const NYC_SEARCH_CENTER = {
+  latitude: 40.7831,
+  longitude: -73.9712,
+};
+const TEAM_SEARCH_RADIUS = MAX_RADIUS;
+const TEAM_SEARCH_MAX_RESULTS = 50;
+
+const dedupeLocations = (locations) => {
+  const seen = {};
+
+  return locations.filter((location) => {
+    if (seen[location.id]) {
+      return false;
+    }
+
+    seen[location.id] = true;
+    return true;
+  });
+};
+
+export const getTeamSearchLocations = (searchString) => {
+  const trimmedSearchString = searchString.trim();
+
+  if (!trimmedSearchString) {
+    return Promise.resolve([]);
+  }
+
+  const sharedParams = {
+    ...NYC_SEARCH_CENTER,
+    radius: TEAM_SEARCH_RADIUS,
+    noServices: true,
+    maxResults: TEAM_SEARCH_MAX_RESULTS,
+  };
+
+  return axios.all([
+    getLocations({
+      ...sharedParams,
+      organizationName: trimmedSearchString,
+    }),
+    getLocations({
+      ...sharedParams,
+      searchString: trimmedSearchString,
+    }),
+  ])
+    .then(results => dedupeLocations([].concat(...results)));
 };
 
 export const getLocationsWithoutServices = () => axios.request({

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,9 +1,19 @@
 import Amplify from 'aws-amplify';
 import config from '../config';
+import {
+  getLocalDevStreetliIdToken,
+  shouldUseLocalDevStreetliAuth,
+} from './devStreetliAuth';
 
 const getIdToken = () => new Promise((resolve) => {
   if (config.disableAuth) {
     return resolve(null);
+  }
+
+  if (shouldUseLocalDevStreetliAuth()) {
+    return getLocalDevStreetliIdToken()
+      .then(idToken => resolve(idToken))
+      .catch(() => resolve(null));
   }
 
   return Amplify.Auth.currentAuthenticatedUser().then((user) => {

--- a/src/services/devStreetliAuth.js
+++ b/src/services/devStreetliAuth.js
@@ -1,0 +1,232 @@
+const DEV_AUTH_QUERY_PARAM = 'devStreetliAuth';
+const DEV_AUTH_ENDPOINT = '/__dev/streetli-auth/relogin';
+const DEV_AUTH_ENABLED_STORAGE_KEY = 'streetlives:streetliDevAuthEnabled';
+const DEV_AUTH_SESSION_STORAGE_KEY = 'streetlives:streetliDevAuthSession';
+const EXPIRY_SKEW_MS = 60 * 1000;
+
+function isBrowser() {
+  return typeof window !== 'undefined' && !!window.location;
+}
+
+function getSessionStorage() {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch (error) {
+    return null;
+  }
+}
+
+function readQueryParam() {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  if (typeof URLSearchParams !== 'undefined') {
+    return new URLSearchParams(window.location.search).get(DEV_AUTH_QUERY_PARAM);
+  }
+
+  const match = window.location.search.match(new RegExp(`[?&]${DEV_AUTH_QUERY_PARAM}=([^&]*)`));
+  return match ? decodeURIComponent(match[1].replace(/\+/g, ' ')) : null;
+}
+
+function isLocalDevHost() {
+  if (!isBrowser()) {
+    return false;
+  }
+
+  const { hostname } = window.location;
+  return (
+    hostname === 'localhost'
+    || hostname === '127.0.0.1'
+    || hostname === '::1'
+    || hostname === '[::1]'
+    || /\.localhost$/i.test(hostname)
+  );
+}
+
+function clearLocalDevStreetliSession() {
+  const storage = getSessionStorage();
+  if (!storage) {
+    return;
+  }
+
+  storage.removeItem(DEV_AUTH_ENABLED_STORAGE_KEY);
+  storage.removeItem(DEV_AUTH_SESSION_STORAGE_KEY);
+}
+
+export function shouldUseLocalDevStreetliAuth() {
+  if (!isBrowser() || !isLocalDevHost()) {
+    return false;
+  }
+
+  const storage = getSessionStorage();
+  const queryFlag = readQueryParam();
+
+  if (queryFlag === '0' || queryFlag === 'false') {
+    clearLocalDevStreetliSession();
+    return false;
+  }
+
+  if (queryFlag === '1' || queryFlag === 'true') {
+    if (storage) {
+      storage.setItem(DEV_AUTH_ENABLED_STORAGE_KEY, '1');
+    }
+    return true;
+  }
+
+  return !!storage && storage.getItem(DEV_AUTH_ENABLED_STORAGE_KEY) === '1';
+}
+
+function normalizeExpiryMs(value) {
+  if (value == null || value === '') {
+    return null;
+  }
+
+  const numericValue = Number(value);
+  if (Number.isFinite(numericValue)) {
+    return numericValue < 1000000000000 ? numericValue * 1000 : numericValue;
+  }
+
+  const parsedValue = Date.parse(value);
+  return Number.isFinite(parsedValue) ? parsedValue : null;
+}
+
+function isFreshSession(session) {
+  if (!session) {
+    return false;
+  }
+
+  const expiresAt = normalizeExpiryMs(session.idTokenExpiresAt || session.accessTokenExpiresAt);
+  return !expiresAt || expiresAt > Date.now() + EXPIRY_SKEW_MS;
+}
+
+function normalizeSession(payload) {
+  const tokens = payload && payload.tokens ? payload.tokens : {};
+  return {
+    username: payload && payload.username ? payload.username : null,
+    email: payload && payload.email ? payload.email : null,
+    authType: payload && payload.authType ? payload.authType : 'cognito_jwt',
+    accessToken: tokens.accessToken || null,
+    idToken: tokens.idToken || null,
+    accessTokenExpiresAt: tokens.accessTokenExpiresAt || null,
+    idTokenExpiresAt: tokens.idTokenExpiresAt || null,
+  };
+}
+
+function readCachedSession() {
+  const storage = getSessionStorage();
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    const session = JSON.parse(storage.getItem(DEV_AUTH_SESSION_STORAGE_KEY) || 'null');
+    return isFreshSession(session) ? session : null;
+  } catch (error) {
+    storage.removeItem(DEV_AUTH_SESSION_STORAGE_KEY);
+    return null;
+  }
+}
+
+function writeCachedSession(session) {
+  const storage = getSessionStorage();
+  if (!storage || !session) {
+    return;
+  }
+
+  storage.setItem(DEV_AUTH_SESSION_STORAGE_KEY, JSON.stringify(session));
+}
+
+function readJsonResponse(response) {
+  return response.text().then((text) => {
+    if (!text) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      return { error: text };
+    }
+  });
+}
+
+export function ensureLocalDevStreetliSession() {
+  if (!shouldUseLocalDevStreetliAuth()) {
+    return Promise.resolve(null);
+  }
+
+  const cachedSession = readCachedSession();
+  if (cachedSession) {
+    return Promise.resolve(cachedSession);
+  }
+
+  return fetch(DEV_AUTH_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+    },
+    credentials: 'same-origin',
+  })
+    .then(response => readJsonResponse(response).then(payload => ({
+      ok: response.ok,
+      status: response.status,
+      payload,
+    })))
+    .then((result) => {
+      if (!result.ok) {
+        const errorPayload = result.payload || {};
+        throw new Error(errorPayload.error
+            || `Streetli dev auth failed with HTTP ${result.status}.`);
+      }
+
+      const session = normalizeSession(result.payload);
+      if (!session.idToken && !session.accessToken) {
+        throw new Error('Streetli dev auth returned no usable token.');
+      }
+
+      writeCachedSession(session);
+      return session;
+    });
+}
+
+function decodeJwtPayload(jwt) {
+  if (!jwt || typeof jwt !== 'string') {
+    return {};
+  }
+
+  const parts = jwt.split('.');
+  if (parts.length < 2 || typeof window.atob !== 'function') {
+    return {};
+  }
+
+  const normalizedPayload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  const paddingLength = (4 - (normalizedPayload.length % 4)) % 4;
+  const paddedPayload = normalizedPayload + new Array(paddingLength + 1).join('=');
+
+  try {
+    return JSON.parse(window.atob(paddedPayload));
+  } catch (error) {
+    return {};
+  }
+}
+
+export function makeLocalDevStreetliIdToken(session) {
+  if (!session || !session.idToken) {
+    return null;
+  }
+
+  return {
+    getJwtToken: () => session.idToken,
+    payload: decodeJwtPayload(session.idToken),
+  };
+}
+
+export function getLocalDevStreetliIdToken() {
+  return ensureLocalDevStreetliSession()
+    .then(session => makeLocalDevStreetliIdToken(session));
+}

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,8 @@
+/* eslint-disable global-require, import/no-commonjs */
+const {
+  attachStreetliDevAuthMiddleware,
+} = require('../devServer/streetliDevAuthMiddleware');
+
+module.exports = function setupProxy(app) {
+  attachStreetliDevAuthMiddleware(app);
+};


### PR DESCRIPTION
## Summary
- Strengthen team map typeahead by querying both organization-name matches and broader location text matches.
- Force the current backend radius search path with `noServices=true` so service-less locations appear before the backend fix lands.
- Dedupe combined suggestion results while preserving org-name results first.

## Why
The current team search only uses `/locations?organizationName=...`, which misses locations without linked services on current production and also cannot match by location name. This gives data-entry users a better chance to find the right record while the backend no-services fix is reviewed.

## Validation
- `npx eslint src/services/api.js src/app/team/mapView/MapView.jsx src/app/team/coronavirus/MapView.jsx`
- `NODE_OPTIONS=--openssl-legacy-provider npx react-scripts build`

## Notes
- Build was run with a temporary `REACT_APP_GMAPS_API_KEY` and Stage API URL for compile-time validation only.
- This branch does not deploy because AWS credentials are not available in the current shell.